### PR TITLE
Package publishing

### DIFF
--- a/packages/eslint-config-ascribe-react/README.md
+++ b/packages/eslint-config-ascribe-react/README.md
@@ -1,64 +1,50 @@
 eslint-config-ascribe-react
 ---------------------------
 
-Provides a React + ES6 [ESLint](http://eslint.org/) configuration against [Ascribe's JavaScript
-style guide](../../README.md), which is based off of [Airbnb's](https://github.com/airbnb/javascript).
+[![npm](https://img.shields.io/npm/v/eslint-config-ascribe-react.svg)](https://www.npmjs.com/package/eslint-config-ascribe-react)
 
-As Airbnb graciously provides a default ESLint configuration (see [here](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb)),
-we extend that and override it when our rules differ (for ES6 rules, we pass through the extended
-rules from our base [eslint-config-ascribe](../eslint-config-ascribe) config).
+> Provides a React + ES6 [ESLint](http://eslint.org/) configuration against [Ascribe's JavaScript style guide](https://github.com/ascribe/javascript).
 
+As Airbnb graciously provides a default ESLint configuration (see [here](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb)), we extend that and override it when our rules differ (for ES6 rules, we pass through the extended rules from our base [eslint-config-ascribe](https://github.com/ascribe/javascript/tree/master/packages/eslint-config-ascribe) config).
 
-Usage
-=====
+## Installation
+
+```bash
+npm install --save-dev eslint-config-ascribe-react babel-eslint eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y eslint
+```
 
 Two configurations are exported:
 
 ### eslint-config-ascribe-react
 
-Includes both ES6 and React configurations. Like airbnb's, it requires `eslint`,
-`eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`, but also
-`babel-eslint` for some ES6+ features that ESLint doesn't natively know about yet.
+Includes both ES6 and React configurations. To use, add `"extends": "ascribe-react"` to your ESLint configuration:
 
-To use:
-
-1. `npm install --save-dev eslint-config-ascribe-react babel-eslint eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y eslint`
-2. Add `"extends": "ascribe-react"` to your ESLint configuration
+```json
+{
+  "extends": "ascribe-react"
+}
+```
 
 ### eslint-config-ascribe-react/react-only
 
-Includes just the React configuration and requires `eslint`, `eslint-plugin-react`,
-`eslint-plugin-jsx-a11y`, and `babel-eslint`.
+Includes just the React configuration. To use, add `"extends": "ascribe-react/react-only"` to your ESLint configuration:
 
-To use:
-
-1. `npm install --save-dev eslint-config-ascribe-react babel-eslint eslint-plugin-react eslint-plugin-jsx-a11y eslint`
-2. Add `"extends": "ascribe-react/react-only"` to your ESLint configuration
+```json
+{
+  "extends": "ascribe-react/react-only"
+}
+```
 
 ## npm releases
 
-For a new **patch release**, execute on the machine where you're logged into your npm account:
+Since this package is part of our styleguide repo, automating npm releases is tricky (can't have multiple Git tags in one repo etc.).
+
+So for now it's all manual. Make sure to actually publish the respective package folder, not the whole repo by going into the package folder first:
 
 ```bash
-npm run release
-```
+cd packages/eslint-config-ascribe-react
 
-Command is powered by [`release-it`](https://github.com/webpro/release-it) package, defined in the `package.json`.
-
-That's what the command does without any user interaction:
-
-- create release commit by updating version in `package.json`
-- create tag for that release commit
-- push commit & tag
-- create a new release on GitHub, with change log auto-generated from commit messages
-- publish to npm as a new release
-
-If you want to create a **minor** or **major release**, use these commands:
-
-```bash
-npm run release-minor
-```
-
-```bash
-npm run release-major
+# update version number in package.json, then:
+git commit -am "Release 2.0.2"
+npm publish
 ```

--- a/packages/eslint-config-ascribe-react/package.json
+++ b/packages/eslint-config-ascribe-react/package.json
@@ -1,12 +1,10 @@
 {
   "name": "eslint-config-ascribe-react",
   "version": "2.0.1",
-  "description": "Ascribe's React ESLint config, following our styleguide (extending from Airbnb's)",
+  "description": "Ascribe's React ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
-    "release": "./node_modules/release-it/bin/release.js --src.tagName='v%s' --github.release --npm.publish --non-interactive",
-    "release-minor": "./node_modules/release-it/bin/release.js minor --src.tagName='v%s' --github.release --npm.publish --non-interactive",
-    "release-major": "./node_modules/release-it/bin/release.js major --src.tagName='v%s' --github.release --npm.publish --non-interactive"
+    
   },
   "repository": {
     "type": "git",
@@ -35,8 +33,5 @@
   },
   "peerDependencies": {
     "babel-eslint": "^7.1.1"
-  },
-  "devDependencies": {
-    "release-it": "^2.7.3"
   }
 }

--- a/packages/eslint-config-ascribe/README.md
+++ b/packages/eslint-config-ascribe/README.md
@@ -1,25 +1,31 @@
 eslint-config-ascribe
 ---------------------
 
-Provides a ES6 [ESLint](http://eslint.org/) configuration against [Ascribe's JavaScript style guide](../../README.md), which is based off of [Airbnb's](https://github.com/airbnb/javascript).
+[![npm](https://img.shields.io/npm/v/eslint-config-ascribe.svg)](https://www.npmjs.com/package/eslint-config-ascribe)
+
+> Provides a ES6 [ESLint](http://eslint.org/) configuration against [Ascribe's JavaScript style guide](https://github.com/ascribe/javascript).
 
 As Airbnb graciously provides a default ES6 ESLint configuration (see [here](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base)), we extend that and override it when our rules differ.
 
 
-Usage
-=====
+## Installation
+
+```bash
+npm install --save-dev eslint-config-ascribe babel-eslint eslint-plugin-import eslint
+```
 
 Two configurations are exported:
 
 ### eslint-config-ascribe
 
 Full ES6 configuration. Like airbnb's, it requires `eslint` and `eslint-plugin-import`, but also
-`babel-eslint` for some ES6+ features that ESLint doesn't natively know about yet.
+`babel-eslint` for some ES6+ features that ESLint doesn't natively know about yet. To use, add `"extends": "ascribe"` to your ESLint configuration:
 
-To use:
-
-1. `npm install --save-dev eslint-config-ascribe babel-eslint eslint-plugin-import eslint`
-2. Add `"extends": "ascribe"` to your ESLint configuration
+```json
+{
+  "extends": "ascribe"
+}
+```
 
 ### eslint-config-ascribe/es5
 
@@ -28,33 +34,24 @@ parser.
 
 To use:
 
-1. `npm install --save-dev eslint-config-ascribe babel-eslint eslint-plugin-import eslint`
-2. Add `"extends": "ascribe/es5"` to your ESLint configuration
+* Add `"extends": "ascribe/es5"` to your ESLint configuration:
+
+```json
+{
+  "extends": "ascribe/es5"
+}
+```
 
 ## npm releases
 
-For a new **patch release**, execute on the machine where you're logged into your npm account:
+Since this package is part of our styleguide repo, automating npm releases is tricky (can't have multiple Git tags in one repo etc.).
+
+So for now it's all manual. Make sure to actually publish the respective package folder, not the whole repo by going into the package folder first:
 
 ```bash
-npm run release
-```
+cd packages/eslint-config-ascribe
 
-Command is powered by [`release-it`](https://github.com/webpro/release-it) package, defined in the `package.json`.
-
-That's what the command does without any user interaction:
-
-- create release commit by updating version in `package.json`
-- create tag for that release commit
-- push commit & tag
-- create a new release on GitHub, with change log auto-generated from commit messages
-- publish to npm as a new release
-
-If you want to create a **minor** or **major release**, use these commands:
-
-```bash
-npm run release-minor
-```
-
-```bash
-npm run release-major
+# update version number in package.json, then:
+git commit -am "Release 3.0.2"
+npm publish
 ```

--- a/packages/eslint-config-ascribe/package.json
+++ b/packages/eslint-config-ascribe/package.json
@@ -1,12 +1,10 @@
 {
   "name": "eslint-config-ascribe",
   "version": "3.0.1",
-  "description": "Ascribe's ESLint config, following our styleguide (extending from Airbnb's)",
+  "description": "Ascribe's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
-    "release": "./node_modules/release-it/bin/release.js --src.tagName='v%s' --github.release --npm.publish --non-interactive",
-    "release-minor": "./node_modules/release-it/bin/release.js minor --src.tagName='v%s' --github.release --npm.publish --non-interactive",
-    "release-major": "./node_modules/release-it/bin/release.js major --src.tagName='v%s' --github.release --npm.publish --non-interactive"
+    
   },
   "repository": {
     "type": "git",
@@ -32,8 +30,5 @@
   },
   "peerDependencies": {
     "babel-eslint": "^7.1.1"
-  },
-  "devDependencies": {
-    "release-it": "^2.7.3"
   }
 }


### PR DESCRIPTION
Releasing & publishing to npm is nicely tricky. Both packages are part of this repo but need to be published individually so automating that is not feasible.

This PR streamlines the respective readme files of those packages and adds instructions for publishing the packages to npm manually, like an animal in the middle ages.